### PR TITLE
Add new platform identifier for Xamarin.iOS10.

### DIFF
--- a/SharpZipLib.Portable.nuspec
+++ b/SharpZipLib.Portable.nuspec
@@ -23,8 +23,8 @@
     <tags>SharpZipLib zip PCL Portable</tags>
   </metadata>
   <files>
-    <file src="\bin\ICSharpCode.SharpZipLib.Portable.dll" target="lib\portable-net45+netcore45+wp8+win8+wpa81+MonoTouch+MonoAndroid\" />
-    <file src="\bin\ICSharpCode.SharpZipLib.Portable.pdb" target="lib\portable-net45+netcore45+wp8+win8+wpa81+MonoTouch+MonoAndroid\" />
-    <file src="\bin\ICSharpCode.SharpZipLib.Portable.xml" target="lib\portable-net45+netcore45+wp8+win8+wpa81+MonoTouch+MonoAndroid\" />
+    <file src="\bin\ICSharpCode.SharpZipLib.Portable.dll" target="lib\portable-net45+netcore45+wp8+win8+wpa81+MonoTouch+MonoAndroid+Xamarin.iOS10\" />
+    <file src="\bin\ICSharpCode.SharpZipLib.Portable.pdb" target="lib\portable-net45+netcore45+wp8+win8+wpa81+MonoTouch+MonoAndroid+Xamarin.iOS10\" />
+    <file src="\bin\ICSharpCode.SharpZipLib.Portable.xml" target="lib\portable-net45+netcore45+wp8+win8+wpa81+MonoTouch+MonoAndroid+Xamarin.iOS10\" />
   </files>
 </package>


### PR DESCRIPTION
I was receiving errors when trying to install this nupkg as a dependency of couchbase lite into a Xamarin iOS project. Adding this new platform identifier (http://developer.xamarin.com/guides/cross-platform/macios/unified/) seems to fix this issue for me.
- modified SharpZipLib.Portable\SharpZipLib.Portable.nuspec to include the new supported platform identifier (Xamarin.iOS10) for each of the file elements
